### PR TITLE
fix env. variable access issue

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,2 +1,2 @@
-export const apiUrl = process.env.API_URL || "http://localhost:4000";
+export const apiUrl = process.env.REACT_APP_API_URL || "http://localhost:4000";
 export const DEFAULT_MESSAGE_TIMEOUT = 3000;


### PR DESCRIPTION
Netlify doesn't have run time processes so I can not make API calls to the heroku server because of the missing API URL. Fixed by react's own implementation.